### PR TITLE
Fix callback issue and make it work in node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 # job-test
 Test repo for Field Javascript job test. Please **fork** this repo to add your responses.
 
+You will notice that the files in this repo are using some ES6 flavoured JavaScript, but only parts of the ES6 specification that are already supported in Node.js (version 6.10+).
+
+That means that you can test your code in the node console, for example, to run `callback.js` you can do:
+
+```
+node javascript/callback.js
+```
+
+which for now (until you finish it) will just print `Results: undefined` to the console.
+
 -- Your friends at Field :)

--- a/javascript/books.js
+++ b/javascript/books.js
@@ -61,4 +61,4 @@ const books = [
   },
 ]
 
-export default books
+module.exports = books

--- a/javascript/callbacks.js
+++ b/javascript/callbacks.js
@@ -1,4 +1,4 @@
-import books from './books'
+const books = require('./books')
 
 const filterBooksWithTitleStartingWithA = (sortedBooks, callback) => {
   let filteredBooks

--- a/javascript/callbacks.js
+++ b/javascript/callbacks.js
@@ -1,5 +1,7 @@
 const books = require('./books')
 
+const print = result => console.log('Result:', result)
+
 const filterBooksWithTitleStartingWithA = (sortedBooks, callback) => {
   let filteredBooks
   /* filter logic here */
@@ -9,7 +11,7 @@ const filterBooksWithTitleStartingWithA = (sortedBooks, callback) => {
 const sortBooksAlphabetically = (books, callback) => {
   let sortedBooks
   /* sorting logic books */
-  return callback(sortedBooks)
+  return callback(sortedBooks, print)
 }
 
 const getBooksAsync = (callback) => {

--- a/javascript/callbacks.js
+++ b/javascript/callbacks.js
@@ -13,7 +13,7 @@ const sortBooksAlphabetically = (books, callback) => {
 }
 
 const getBooksAsync = (callback) => {
-  setTimeout((books) => {
+  setTimeout(() => {
     callback(books, filterBooksWithTitleStartingWithA)
   }, 2000)
 }


### PR DESCRIPTION
I fixed the missing callback issue in `callback.js` by adding an extra function that prints the results to the console. That is, the books are imported, ordered, filtered by the ones that have a title starting with 'a' and printed to the console. Other option to fix it would be to just remove the need of a callback in `filterBooksWithTitleStartingWithA`.

I also changed the ES6 module import/export to the CommonJS version to be able to run it in node while I was fixing it, and then thought that could be a nice thing to leave there, so that candidates can easily run their own code.

I think with this I've made the test a bit more approachable, so if that is not the idea, feel free to change or comment :-).